### PR TITLE
Remove browser folder from .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,4 +8,3 @@ rel/
 site/
 dev/
 triplesec_standalone.html
-browser/


### PR DESCRIPTION
With the browser folder being in NPM ignore, there isn't a way to use this in the browser via NPM install.